### PR TITLE
contact id validation test

### DIFF
--- a/models/staging/web/_web__sources.yml
+++ b/models/staging/web/_web__sources.yml
@@ -10,6 +10,9 @@ sources:
       - name: transactions
         description: Contains a record per transaction made by customers
         columns:
+          - name: contact_id
+            tests:
+              - is_contact_valid
           - name: id
             tests:
               - unique

--- a/tests/is_contact_valid.sql
+++ b/tests/is_contact_valid.sql
@@ -1,0 +1,28 @@
+{% test is_contact_valid(model, column_name) %}
+
+with transactions as (
+
+    select distinct 
+        {{ column_name }}
+    from {{ model }}
+    
+
+),
+
+validation_errors as (
+
+    select
+        even_field
+
+    from transactions
+      
+      left join {{ source('salesforce','contacts') }}  as contacts
+      on contacts.id = transactions.contact_id
+    where
+      contacts.id is null
+)
+
+select *
+from validation_errors
+
+{% endtest %}  


### PR DESCRIPTION
This PR creates a new validation test to ensure every contact_id within transaction is valid by joining onto the contacts table.
Where records don't match with an id within the contacts table this test will fail.